### PR TITLE
Tunnel timeout support and kill process on failure

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -23,13 +23,13 @@ Tunnel.prototype.run = function(hostOrSettings, callback){
   var parts = hostAndPort.split(':')
   var host = parts[0]
   var port = parts[1]
-
+  
   bs.configure(function(){
     var config = bs.config
     callback = callback || function(){}
     var jarpath = path.join(config.profileDir, 'BrowserStackTunnel.jar')
     key = key || (usePrivateKey ? config.privateKey : config.apiKey)
-    timeout = timeout || config.tunnelTimeout || config.timeout || 5000;
+    timeout = timeout || config.tunnelTimeout || config.timeout || 5000
     var exe = 'java'
     var args = [
       '-jar',


### PR DESCRIPTION
Establishing the tunnel takes longer than the default timeout for me. I have added the option to specify a timeout to override the default in the options passed to Tunnel.run, or in the config file under two properties; tunnelTimeout and timeout, in case there may be timeouts for each component in the future.

The addition of self.process.kill() ensures that the java process is terminated if it outputs a failure or we timeout. Particularly in the case of a timeout I believe the java process was left running.

Separately I'm sending a pull request to the browserstack-cli to add support for the new timeout option in Tunnel.run
