### PR TITLE
do not ask password anymore and use access key to authenticate api calls

### DIFF
--- a/lib/browserstack.js
+++ b/lib/browserstack.js
@@ -34,7 +34,7 @@ BrowserStack.prototype = {
       fs.readFile(configFile, function(err, text){
         if (!err){
           var fileConfig = JSON.parse(text)
-          fileConfig.password = self.base64Decode(fileConfig.password)
+          fileConfig.password = fileConfig.apiKey;
           self.config = extend(fileConfig, self.config)
         }
         self.createClient()

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -12,17 +12,10 @@ function Setup(config){
 Setup.prototype.getInfo = function getInfo(program, callback){
   var self = this
   program.prompt('Username: ', function(username){
-    program.password('Password: ', function(password){
-      program.prompt('Tunnel private key (see while logged in http://www.browserstack.com/local-testing): ', function(webApiKey){
-        program.prompt('Tunnel API key (see while logged in http://www.browserstack.com/automated-browser-testing-api#automated-local-testing): ', function(testingApiKey){
-          var encodedPassword = self.base64Encode(password)
-          callback({
-            username: username,
-            password: encodedPassword,
-            privateKey: webApiKey,
-            apiKey: testingApiKey
-          })
-        })
+    program.prompt('Access key: ', function(testingApiKey){
+      callback({
+        username: username,
+        apiKey: testingApiKey
       })
     })
   })

--- a/test/browserstack_tests.js
+++ b/test/browserstack_tests.js
@@ -135,11 +135,10 @@ suite('browserstack', function(){
       bs.configure(function(config){
         var expected = extend(require(path.join(profileDir, 'browserstack.json')), orgConfig)
         assert.equal(config.username, 'johnsmith')
-        assert.equal(config.privateKey, '38etonOu04Abet')
         assert.equal(config.apiKey, '53cEoaN1o339oA')
+        assert.equal(config.password, '53cEoaN1o339oA')
         assert.equal(config.profileDir, profileDir)
         assert.equal(bs.config, config)
-        assert.equal(bs.config.password, 's\u000bq%kw!\u0006')
         done()
       })
     })

--- a/test/download_tests.js
+++ b/test/download_tests.js
@@ -47,7 +47,7 @@ suite('download', function(){
   })
 
   setup(function(done){
-    exec('rm downloads/*', function(){ done() })
+    exec('rm -f downloads/* && mkdir -p downloads/', function(){ done() })
   })
 
 })


### PR DESCRIPTION
I changed the setup to not ask the password anymore and use the (now) unique access key.

I think this is very important because the api is HTTP, I don't want my password to be sent as clear text. BrowserStack support basic authentication using the access key.

All tests are green on my side.
