### PR TITLE
Replace jar with browserstacktunnel-wrapper

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var BrowserStackTunnel = require('browserstacktunnel-wrapper')
 
 function Tunnel(bs){
   this.bs = bs
@@ -10,7 +11,7 @@ Tunnel.prototype.run = function(hostOrSettings, callback){
   var key
   var usePrivateKey
   var timeout
-  
+
   if (typeof hostOrSettings === 'string'){
     hostAndPort = hostOrSettings
   }else{ // object
@@ -19,39 +20,84 @@ Tunnel.prototype.run = function(hostOrSettings, callback){
     usePrivateKey = hostOrSettings.usePrivateKey
     timeout = hostOrSettings.timeout
   }
-   
+
   var parts = hostAndPort.split(':')
   var host = parts[0]
   var port = parts[1]
-  
+
   bs.configure(function(){
     var config = bs.config
     callback = callback || function(){}
-    var jarpath = path.join(config.profileDir, 'BrowserStackTunnel.jar')
     key = key || (usePrivateKey ? config.privateKey : config.apiKey)
     timeout = timeout || config.tunnelTimeout || config.timeout || 5000
-    var exe = 'java'
-    var args = [
-      '-jar',
-      jarpath,
-      key,
-      host + ',' + port + ',0'
-    ]
-    self.process = bs.Process(exe, args)
-      .goodIfMatches(/You can now access your local server/, timeout)
-      .good(function(){
-        callback(null)
-      })
-      .badIfMatches(/\*\* Error: (.*)$/m)
-      .bad(function(data, stdout, stderr){
-        self.process.kill()
-        callback(data)
-      })
+
+    var tunnelConfig = {
+      key: key,
+      hosts: [{
+        name: host,
+        port: port,
+        sslFlag: 0
+      }]
+    }
+
+    var binDirConfigKey = 'win32Bin'
+
+    switch (process.platform) {
+      case 'linux':
+        binDirConfigKey = (process.arch === 'x64') ? 'linux64Bin' : 'linux32Bin'
+        break
+
+      case 'darwin':
+        binDirConfigKey = 'osxBin'
+        break
+    }
+
+    tunnelConfig[binDirConfigKey] = config.profileDir
+    browserStackTunnel = new BrowserStackTunnel(tunnelConfig)
+
+    var callbackOnce = function (err) {
+      if (callback) {
+        callback(err)
+        callback = null
+      }
+    }
+
+    browserStackTunnel.start(function (err) {
+      if (!err) {
+        self.tunnel = browserStackTunnel
+
+        clearTimeout(self.tunnelStartTimeout)
+        self.tunnelStartTimeout = null
+      }
+
+      callbackOnce(err)
+    })
+
+    self.tunnelStartTimeout = setTimeout(function () {
+      if (!self.tunnel) {
+        browserStackTunnel.stop(function () {
+          self.tunnel = null
+          callbackOnce(new Error('Failed to start tunnel in ' + timeout + 'ms'))
+        })
+      }
+    }, timeout)
   }.bind(bs))
 }
 
-Tunnel.prototype.stop = function(){
-  if (this.process) this.process.kill()
+Tunnel.prototype.stop = function(callback){
+  var self = this
+  if (!this.tunnel) {
+    callback && callback()
+    return
+  }
+
+  this.tunnel.stop(function (err) {
+    if (!err) {
+      self.tunnel = null
+    }
+
+    callback && callback(err)
+  })
 }
 
 module.exports = Tunnel

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "progress": "~0.1.0",
     "commander": "~1.1.1",
     "browserstack": "git://github.com/airportyh/node-browserstack#v3",
+    "browserstacktunnel-wrapper": "^1.4.2",
     "async": "~0.2.7",
     "did_it_work": "~0.0.3",
     "sinon": "~1.7.1",


### PR DESCRIPTION
Uses the `browserstacktunnel-wrapper` module instead of the unsupported `BrowserStackTunnel.jar` file to create a tunnel to BrowserStack.
